### PR TITLE
Make it easier to run the stats code locally for debugging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,11 @@ elasticsearch==1.6.0
 # sha256: J3czd27VOLsv707jyA1xuTCeakPRuJGh39Bs6Sg1l6M
 pyelasticsearch==1.4
 
+# sha256: dadcddc0aefbf99eea214e0f1232b94f2fa9bd98fa8353711dacb112bfcbbb2a
+# sha256: 9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac
+# sha256: f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98
+nose==1.3.7
+
 # sha256: KjGJ950ce4ohSaDng8C0IX-tmzCm59YEUPJVPcLA5X4
 simplejson==3.6.5
 


### PR DESCRIPTION
These changesets:
- Add `nose` as a requirement, only really for tests, but it helps for people getting set up.
- Adds `--no-publish` option to avoid the code that attempts to publish the results, and saves hacking.
- Adds `--beginning-of-time` (or `-b`) option to allow easily changing the time when stats processing starts.
